### PR TITLE
Pull Request: fix errors, add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,16 +10,28 @@ var deepFind = function(obj, path) {
   }
 
   if (!Array.isArray(path)) {
-    path = path.concat();
+    throw "path must be either an array or a string";
   }
 
   return path.reduce(function (o, part) {
     var keys = part.match(/\[(.*?)\]/);
     if (keys) {
-      var key = part.replace(keys[0], '');
-      return o[key][keys[1]];
-    }
-    return o[part];
+	  var key = part.replace(keys[0], '');
+	  if (!((typeof o === "undefined") || (o === null))) {
+		  if (!((typeof o[key] === "undefined") || (o[key] === null))) {
+			return o[key][keys[1]];
+		  } else {
+			  return undefined;
+		  }
+	  } else {
+		  return undefined;
+	  }
+	}
+	if (!((typeof o === "undefined") || (o === null))) {
+		return o[part];
+	} else {
+		return undefined;
+	}
   }, obj);
 };
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var deepFind = function(obj, path) {
 
-  if (((typeof obj !== "object") && (typeof obj !== "function")) | obj === null) {
+  if (((typeof obj !== "object") && (typeof obj !== "function")) || obj === null) {
 	  return undefined;
   }
   if (typeof path === 'string') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deep-find",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "find value for deep nesting keys",
   "bugs": {
     "url": "yashprit/deep-find/issues"
@@ -27,7 +27,7 @@
   ],
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "mocha": "^3.2.0"
+    "mocha": "^7.1.1"
   },
   "scripts": {
     "test": "node benchmark.js && mocha"

--- a/test.js
+++ b/test.js
@@ -14,7 +14,7 @@ it("should except string as path", function() {
   }
 
   var value = deepFind(obj, 'employee.name.first');
-  assert.equal('yash', value)
+  assert.strictEqual('yash', value)
 });
 
 it("should except array as path", function() {
@@ -28,7 +28,7 @@ it("should except array as path", function() {
   }
 
   var value = deepFind(obj, ['employee', 'name', 'first']);
-  assert.equal('yash', value)
+  assert.strictEqual('yash', value)
 });
 
 it("should handle array as value", function() {
@@ -47,8 +47,47 @@ it("should handle array as value", function() {
   }
 
   var value = deepFind(obj, ['employees[0]', 'name', 'first']);
-  assert.equal('yash', value)
+  assert.strictEqual('yash', value)
 });
+
+it("should handle non existant array value", function() {
+	var obj = {
+	  employees: [{
+		name: {
+		  first: 'yash',
+		  last: 'singh'
+		}
+	  }, {
+		name: {
+		  first: 'ruby',
+		  last: 'singh'
+		}
+	  }]
+	}
+
+	var value = deepFind(obj, ['employees[2]', 'name', 'first']);
+	assert.strictEqual(undefined, value)
+  });
+
+  it("should handle non existant parent key", function() {
+	var obj = {
+	  employees: [{
+		name: {
+		  first: 'yash',
+		  last: 'singh'
+		}
+	  }, {
+		name: {
+		  first: 'ruby',
+		  last: 'singh'
+		}
+	  }]
+	}
+
+	var value = deepFind(obj, ['employees[0]', 'person', 'first']);
+	assert.strictEqual(undefined, value)
+  });
+
 
 it("should handle array as value", function() {
   var obj = {
@@ -66,10 +105,10 @@ it("should handle array as value", function() {
   }
 
   var value = deepFind(obj, 'employees[0].name.first');
-  assert.equal('yash', value)
+  assert.strictEqual('yash', value)
 });
 
-it("should return null when no result is found", function() {
+it("should return undefined when no result is found", function() {
   var obj = {
     employees: [{
       name: {
@@ -85,8 +124,22 @@ it("should return null when no result is found", function() {
   }
 
   var value = deepFind(obj, 'employees[0].name.address');
-  assert.equal(null, value)
+  assert.strictEqual(undefined, value)
 });
+
+it("should handle null object", function() {
+	var obj = null;
+
+	var value = deepFind(obj, 'employees[0].name.address');
+	assert.strictEqual(undefined, value)
+  });
+
+  it("should handle invalid datatypes", function() {
+	var obj = "test";
+
+	var value = deepFind(obj, 'employees[0].name.address');
+	assert.strictEqual(undefined, value)
+  });
 
 it("should handle string selectors", function() {
   var obj = {
@@ -99,5 +152,5 @@ it("should handle string selectors", function() {
   }
 
   var value = deepFind(obj, 'employees[spaced key].first');
-  assert.equal('yash', value)
+  assert.strictEqual('yash', value)
 });


### PR DESCRIPTION
Previously deep-find would throw an unhandled exception if anything but the last element in the path was missing.  Now it returns "undefined" if the last element or any of the elements in the path do not exist.

Updated the tests to reflect this.

Changed to throw an exception if the path is an invalid data type.